### PR TITLE
Nrnv3 KML patch and latest release updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/annual_objectives.md
+++ b/.github/ISSUE_TEMPLATE/annual_objectives.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **Description of tasks**
 Annual objectives for <year>.
-- [ ] update year specified in license file: `LICENSE.md` / `LICENSE-fr.md`
+- [ ] update year specified in license file: `LICENSE.md`, `LICENSE-fr.md`, `docs/source/conf.py`
 - [ ] process available data sources:
   - [ ] <source>
   - [ ] ...

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 

--- a/docs/_internal/validation_errors.rst
+++ b/docs/_internal/validation_errors.rst
@@ -221,106 +221,91 @@ E01501
 :Validation: NID linkages.
 :Description: ID(s) from the specified attribute column are not present in the linked dataset's "NID" attribute column.
 
-E016
-----
-
-:Validation: Conflicting pavement status.
-
 E01601
-^^^^^^
-
-:Description: Attribute "pavsurf" cannot equal "None" when attribute "pavstatus" equals "Paved".
-
-E01602
-^^^^^^
-
-:Description: Attribute "unpavsurf" cannot equal "None" when attribute "pavstatus" equals "Unpaved".
-
-E01701
 ------
 
 :Validation: Point proximity.
 :Description: Points must be >= 5 meters from each other.
 
-E018
+E017
 ----
 
 :Validation: Structure attributes.
 
-E01801
+E01701
 ^^^^^^
 
 :Description: Dead end road segments must have attribute "structtype" equal to "None" or the default value.
 
-E01802
+E01702
 ^^^^^^
 
 :Description: Structures must be contiguous (i.e. all line segments must be touching). The specified structure
     represents all geometries where attribute "structid" equals the specified structure ID.
 
-E01803
+E01703
 ^^^^^^
 
 :Description: Attribute "structid" must be identical and not the default value for all line segments constituting a
     contiguous structure (i.e. all connected line segments where attribute "structtype" is not equal to the default
     value).
 
-E01804
+E01704
 ^^^^^^
 
 :Description: Attribute "structtype" must be identical and not the default value for all line segments constituting a
     contiguous structure (i.e. all connected line segments where attribute "structtype" is not equal to the default
     value).
 
-E01901
+E01801
 ------
 
 :Validation: Road class - route number relationship.
 :Description: Attribute "rtnumber1" cannot equal the default value or "None" when attribute "roadclass" equals one of
     the following: "Expressway / Highway", "Freeway".
 
-E02001
+E01901
 ------
 
 :Validation: Self-intersecting road elements.
 :Description: Road segments which constitute a self-intersecting road element must have attribute "roadclass" equal to
     one of the following: "Expressway / Highway", "Freeway", "Ramp", "Rapid Transit", "Service Lane".
 
-E02101
+E02001
 ------
 
 :Validation: Self-intersecting structures.
 :Description: Line segments which intersect themselves must have a "structtype" attribute not equal to "None".
 
-E02201
+E02101
 ------
 
 :Validation: Route contiguity.
 :Description: Routes must be contiguous (i.e. all line segments must be touching). The specified route represents all
     geometries where one of the specified route name attributes equals the specified route name.
 
-E023
+E022
 ----
 
 :Validation: Speed.
 
-E02301
+E02201
 ^^^^^^
 
 :Description: Attribute "speed" must be between 5 and 120, inclusively.
 
-E02302
+E02202
 ^^^^^^
 
 :Description: Attribute "speed" must be a multiple of 5.
 
-E02401
+E02301
 ------
 
 :Validation: Encoding.
 :Description: Attribute contains one or more question mark ("?"), which may be the result of invalid character encoding.
 
-E02501
+E02401
 ------
 
 :Validation: Out-of-scope.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,4 +53,4 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ['source/_static']

--- a/docs/source/completion_rates.rst
+++ b/docs/source/completion_rates.rst
@@ -29,23 +29,23 @@ Coverage                             0     0     0     0     0     0     0    88
 Creation Date                        0     0     0    99     0    99     0    88   100   100     0    99     1    45
 Dataset Name                         0     0     0   100     0   100     0   100   100   100     0   100   100    54
 Planimetric Accuracy                 0     0     0     0     0   100     0     0   100   100     0    99     1    31
-Provider                             0     0     0   100     0   100     0   100     0   100     0    99     1    38
+Provider                             0     0     0   100     0   100     0   100    84   100     0    99     1    45
 Revision Date                        0     0     0   100     0   100     0   100   100   100     0    99    98    54
-Standard Version                     0     0     0   100     0   100   100   100     0   100     0   100   100    54
-Alternate Street Name NID Left       0     0     0     0     0     0     0     0   100     0     0     0     0     8
-Alternate Street Name NID Right      0     0     0     0     0     0     0     0   100     0     0     0     0     8
+Standard Version                     0     0     0   100     0   100   100   100   100   100     0   100   100    62
+Alternate Street Name NID Left       0     0     0     0     0     0     0     0     0     0     0     0     0     0
+Alternate Street Name NID Right      0     0     0     0     0     0     0     0     0     0     0     0     0     0
 Digitizing Direction Flag Left       0     0     0    99     0   100     0   100     0    54     0     0    28    29
 Digitizing Direction Flag Right      0     0     0    99     0   100     0   100     0    55     0     0    27    29
-First House Number Left              0     0     0   100     0   100     0   100    99    54     0     0    28    37
-First House Number Right             0     0     0   100     0   100     0   100   100    55     0     0    27    37
+First House Number Left              0     0     0   100     0   100     0   100    84    54     0     0    28    36
+First House Number Right             0     0     0   100     0   100     0   100    84    55     0     0    27    36
 First House Number Suffix Left       0     0     0    99     0     0     0   100     0     0     0     0     1    15
 First House Number Suffix Right      0     0     0    99     0     0     0   100     0     0     0     0     1    15
 First House Number Type Left         0     0     0   100     0    73     0   100     0    54     0     0    28    27
 First House Number Type Right        0     0     0   100     0    73     0   100     0    55     0     0    27    27
-House Number Structure Left          0     0     0   100     0   100     0   100    98    54     0     0    28    37
-House Number Structure Right         0     0     0   100     0   100     0   100    98    55     0     0    27    37
-Last House Number Left               0     0     0   100     0   100     0   100   100    54     0     0    28    37
-Last House Number Right              0     0     0   100     0   100     0   100   100    55     0     0    27    37
+House Number Structure Left          0     0     0   100     0   100     0   100   100    54     0     0    28    37
+House Number Structure Right         0     0     0   100     0   100     0   100   100    55     0     0    27    37
+Last House Number Left               0     0     0   100     0   100     0   100    84    54     0     0    28    36
+Last House Number Right              0     0     0   100     0   100     0   100    84    55     0     0    27    36
 Last House Number Suffix Left        0     0     0    99     0     0     0   100     0     0     0     0     1    15
 Last House Number Suffix Right       0     0     0    99     0     0     0   100     0     0     0     0     1    15
 Last House Number Type Left          0     0     0   100     0    73     0   100     0    54     0     0    28    27
@@ -83,12 +83,12 @@ Attribute                AB    BC    MB    NB    NL    NS    NT    NU    ON    P
 =====================  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  =====
 Acquisition Technique   100   100   100     0   100   100   100     0   100   100     0    99   100    77
 Coverage                100   100   100     0   100     0   100     0     0   100     0    99   100    61
-Creation Date           100   100   100     0   100   100   100     0   100   100     0   100   100    77
+Creation Date           100   100   100     0   100   100   100     0     0   100     0   100   100    69
 Dataset Name            100   100   100     0   100   100   100     0   100   100     0    99   100    77
 Planimetric Accuracy    100   100   100     0   100   100   100     0   100   100     0    99   100    77
-Provider                100   100   100     0   100   100   100     0     0   100     0    99   100    69
+Provider                100   100   100     0   100   100   100     0     1   100     0    99   100    69
 Revision Date           100   100   100     0   100   100   100     0   100   100     0    99   100    77
-Standard Version        100   100   100     0   100   100   100     0     0   100     0   100   100    69
+Standard Version        100   100   100     0   100   100   100     0   100   100     0   100   100    77
 Blocked Passage Type    100     0   100     0    99    99   100     0   100   100     0    99   100    69
 NID                     100   100   100     0   100   100   100     0   100   100     0   100   100    77
 Road Element NID        100   100   100     0   100   100   100     0   100   100     0   100   100    77
@@ -107,26 +107,26 @@ Coverage                100   100   100     0   100   100     0     0     0   10
 Creation Date           100   100   100   100   100     0    25     0   100   100   100   100   100    79
 Dataset Name            100   100   100   100   100   100   100     0   100   100   100   100   100    92
 Planimetric Accuracy    100   100   100     0   100   100    25     0   100   100   100   100   100    79
-Provider                100   100   100   100   100   100   100     0     0   100   100   100   100    85
+Provider                100   100   100   100   100   100   100     0    70   100   100   100   100    90
 Revision Date           100   100   100   100   100     8     0     0   100   100   100   100   100    78
-Standard Version        100   100   100   100   100   100   100     0     0   100   100   100   100    85
+Standard Version        100   100   100   100   100   100   100     0   100   100   100   100   100    92
 Closing Period            0     0     0   100     0   100   100     0     0   100     0     0     0    31
 Ferry Segment ID        100   100   100   100   100   100   100     0   100   100   100   100   100    92
-Functional Road Class   100   100   100     0   100     8   100     0     0   100   100   100   100    70
+Functional Road Class   100   100   100     0   100     8   100     0   100   100   100   100   100    78
 NID                     100   100   100   100   100   100   100     0   100   100   100   100   100    92
-Route Name English 1    100   100   100   100   100     0   100     0   100   100   100   100   100    85
-Route Name English 2    100   100   100   100   100     0   100     0   100   100   100     0   100    77
-Route Name English 3    100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Name English 4    100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Name French 1     100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Name French 2     100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Name French 3     100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Name French 4     100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Number 1          100   100   100   100   100     0   100     0   100   100   100     0   100    77
-Route Number 2          100   100   100   100   100     0   100     0   100   100   100     0   100    77
-Route Number 3          100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Number 4          100   100   100   100   100     0     0     0   100   100   100     0   100    69
-Route Number 5          100   100   100   100   100     0     0     0   100   100   100     0   100    69
+Route Name English 1    100   100   100   100   100     0   100     0    96   100   100   100   100    84
+Route Name English 2    100   100   100   100   100     0   100     0     6   100   100     0   100    70
+Route Name English 3    100   100   100   100   100     0     0     0     0   100   100     0   100    62
+Route Name English 4    100   100   100   100   100     0     0     0     0   100   100     0   100    62
+Route Name French 1     100   100   100   100   100     0     0     0     3   100   100     0   100    62
+Route Name French 2     100   100   100   100   100     0     0     0     0   100   100     0   100    62
+Route Name French 3     100   100   100   100   100     0     0     0     0   100   100     0   100    62
+Route Name French 4     100   100   100   100   100     0     0     0     0   100   100     0   100    62
+Route Number 1          100   100   100   100   100     0   100     0     6   100   100     0   100    70
+Route Number 2          100   100   100   100   100     0   100     0     0   100   100     0   100    69
+Route Number 3          100   100   100   100   100     0     0     0     0   100   100     0   100    62
+Route Number 4          100   100   100   100   100     0     0     0     0   100   100     0   100    62
+Route Number 5          100   100   100   100   100     0     0     0     0   100   100     0   100    62
 =====================  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  =====
 
 Junction (junction)
@@ -163,49 +163,49 @@ Coverage                                        100   100   100     0   100   10
 Creation Date                                   100   100   100    99   100    99    84    88   100   100   100    99     1    90
 Dataset Name                                    100   100   100   100   100   100   100   100   100   100   100   100   100   100
 Planimetric Accuracy                            100   100   100     0   100   100    87     0   100   100   100    99     1    76
-Provider                                        100   100   100   100   100   100    99   100     0   100   100    99     1    85
+Provider                                        100   100   100   100   100   100    99   100    84   100   100    99     1    91
 Revision Date                                   100   100   100   100   100   100     0   100   100   100   100    99    98    92
-Standard Version                                100   100   100   100   100   100   100   100     0   100   100   100   100    92
+Standard Version                                100   100   100   100   100   100   100   100   100   100   100   100   100   100
 Address Range Digitizing Direction Flag Left    100   100   100    99   100     0     6   100     0    54   100     0    28    61
 Address Range Digitizing Direction Flag Right   100   100   100    99   100     0     6   100     0    55   100     0    27    61
 Address Range NID                               100   100   100   100   100    73   100   100   100   100   100   100   100    98
 Closing Period                                    0     1     0     1     0    28     2     0     0    82     1     0     1     9
-Exit Number                                     100   100   100   100   100     0     0     0   100     0   100     1     0    54
-First House Number Left                          90   100    65   100    99    73     6   100   100    54    98   100    28    78
-First House Number Right                         90   100    65   100    99    73     6   100   100    55    98   100    27    78
-Functional Road Class                           100   100   100    99   100    97    99    83   100   100   100    99    97    98
-Last House Number Left                           90   100    65   100    99    73     6   100   100    54    98   100    28    78
-Last House Number Right                          90   100    65   100    99    73     6   100   100    55    98   100    27    78
+Exit Number                                     100   100   100   100   100     0     0     0     1     0   100     1     0    46
+First House Number Left                          90   100    65   100    99    73     6   100    84    54    98   100    28    77
+First House Number Right                         90   100    65   100    99    73     6   100    84    55    98   100    27    77
+Functional Road Class                           100   100   100    99   100    97    99    83    98   100   100    99    97    98
+Last House Number Left                           90   100    65   100    99    73     6   100    84    54    98   100    28    77
+Last House Number Right                          90   100    65   100    99    73     6   100    84    55    98   100    27    77
 NID                                             100   100   100   100   100   100   100   100   100   100   100   100   100   100
 Number of Lanes                                 100   100   100    99   100    99    76    81   100   100   100    99    98    96
-Official Place Name Left                        100   100   100    94   100    73    87   100    85    99    96    99   100    95
-Official Place Name Right                       100   100   100    94   100    73    87   100    85    99    96    99   100    95
+Official Place Name Left                        100   100   100    94   100    73    87   100     4    99    96    99   100    89
+Official Place Name Right                       100   100   100    94   100    73    87   100     4    99    96    99   100    89
 Official Street Name Concatenated Left          100   100   100    94   100    73    39   100    85    96    96    28    77    84
 Official Street Name Concatenated Right         100   100   100    94   100    73    39   100    85    96    96    28    77    84
-Paved Road Surface Type                          58    16    46    99    31    49   100    93    23   100    15    69   100    61
+Paved Road Surface Type                          58    16    46    99    31    49   100    93    24   100    15    69   100    62
 Pavement Status                                 100   100   100    99   100   100   100    93   100   100   100    99   100    99
 Road Jurisdiction                                99   100     0     0     0    73     0    54   100   100     0     0    85    47
 Road Segment ID                                 100   100   100   100   100   100   100   100   100   100   100   100   100   100
-Route Name English 1                            100   100   100   100   100     1    15     0   100     3   100     1    27    57
-Route Name English 2                            100   100   100   100   100     0    12     0   100     0   100     1     1    55
-Route Name English 3                            100   100   100   100   100     0     1     0   100     0   100     1     0    54
-Route Name English 4                            100   100   100   100   100     0     0     0   100     0   100     1     0    54
-Route Name French 1                             100   100   100   100   100     1     0     0   100     3   100     1    27    56
-Route Name French 2                             100   100   100   100   100     0     0     0   100     0   100     1     1    54
-Route Name French 3                             100   100   100   100   100     0     0     0   100     0   100     1     0    54
-Route Name French 4                             100   100   100   100   100     0     0     0   100     0   100     1     0    54
-Route Number 1                                  100   100   100    99   100    12    11     0   100    36   100     9   100    67
-Route Number 2                                  100   100   100   100   100     0    11     0   100     1   100     1   100    63
-Route Number 3                                  100   100   100   100   100     0     1     0   100     1   100     1     0    54
-Route Number 4                                  100   100   100   100   100     0     0     0   100     0   100     1     0    54
-Route Number 5                                  100   100   100   100   100     0     0     0   100     0   100     1     0    54
+Route Name English 1                            100   100   100   100   100     1    15     0     2     3   100     1    27    50
+Route Name English 2                            100   100   100   100   100     0    12     0     1     0   100     1     1    47
+Route Name English 3                            100   100   100   100   100     0     1     0     1     0   100     1     0    46
+Route Name English 4                            100   100   100   100   100     0     0     0     1     0   100     1     0    46
+Route Name French 1                             100   100   100   100   100     1     0     0     1     3   100     1    27    49
+Route Name French 2                             100   100   100   100   100     0     0     0     1     0   100     1     1    46
+Route Name French 3                             100   100   100   100   100     0     0     0     1     0   100     1     0    46
+Route Name French 4                             100   100   100   100   100     0     0     0     1     0   100     1     0    46
+Route Number 1                                  100   100   100    99   100    12    11     0    11    36   100     9   100    60
+Route Number 2                                  100   100   100   100   100     0    11     0     1     1   100     1   100    55
+Route Number 3                                  100   100   100   100   100     0     1     0     1     1   100     1     0    46
+Route Number 4                                  100   100   100   100   100     0     0     0     1     0   100     1     0    46
+Route Number 5                                  100   100   100   100   100     0     0     0     1     0   100     1     0    46
 Speed Restriction                                 1     0     0    56     0     0     0    96   100    79     0    99     0    33
-Structure Name English                           98    98    97    99   100     0     1     0   100     1   100     1     1    54
-Structure Name French                            98    98    97    96   100     0     0     0   100     1   100     1     0    53
+Structure Name English                           98    98    97    99   100     0     1     0     1     1   100     1     1    46
+Structure Name French                            98    98    97    96   100     0     0     0     1     1   100     1     0    46
 Structure ID                                    100   100   100   100   100   100   100   100   100   100   100     1   100    92
 Structure Type                                  100   100   100   100   100   100     1   100   100   100   100    99     1    85
-Traffic Direction                                61   100     0    99     0    98     0    88   100   100     0     0    95    57
-Unpaved Road Surface Type                        78    83    53    99    73    50    72    93    76    99    83    99    88    80
+Traffic Direction                                61   100     0    99     0    98     0    88     0   100     0     0    95    49
+Unpaved Road Surface Type                        78    83    53    99    73    50    72    93    75    99    83    99    88    80
 =============================================  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  =====
 
 Street and Place Names (strplaname)
@@ -221,20 +221,20 @@ Coverage                  0     0     0     0     0     0     0    68     0   10
 Creation Date             0     0     0    99     0    99    88    68   100   100     0    99     1    50
 Dataset Name              0     0     0   100     0   100   100   100   100   100     0   100   100    62
 Planimetric Accuracy      0     0     0     0     0   100    91     0   100   100     0    99     1    38
-Provider                  0     0     0   100     0   100    99   100     0   100     0    99     2    46
+Provider                  0     0     0   100     0   100    99   100    93   100     0    99     2    53
 Revision Date             0     0     0   100     0   100     0   100   100   100     0    99    95    53
-Standard Version          0     0     0   100     0   100   100   100     0   100     0   100   100    54
+Standard Version          0     0     0   100     0   100   100   100   100   100     0   100   100    62
 Directional Prefix        0     0     0    99     0   100     0   100   100   100     0     1   100    46
 Directional Suffix        0     0     0   100     0   100     1   100   100   100     0    10   100    47
 Municipal Quadrant        0     0     0   100     0   100     0   100     0     0     0     0     0    23
 NID                       0     0     0   100     0   100   100   100   100   100     0   100   100    62
-Place Name                0     0     0    98     0   100    84   100   100    99     0    99   100    60
+Place Name                0     0     0    98     0   100    84   100     5    99     0    99   100    53
 Place Type                0     0     0     1     0     0    77   100     0     0     0     0    73    19
 Province                  0     0     0    99     0   100   100   100   100   100     0   100   100    61
 Street Name Article       0     0     0   100     0     0     1   100     1     0     0     1     0    16
-Street Name Body          0     0     0   100     0   100    92   100    99    96     0    73    95    58
-Street Type Prefix        0     0     0   100     0   100     1   100    99     4     0    17   100    40
-Street Type Suffix        0     0     0   100     0    99    81   100    99    91     0    55   100    56
+Street Name Body          0     0     0   100     0   100    92   100    97    96     0    73    95    58
+Street Type Prefix        0     0     0   100     0   100     1   100   100     4     0    17   100    40
+Street Type Suffix        0     0     0   100     0    99    81   100   100    91     0    55   100    56
 =====================  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  =====
 
 Toll Point (tollpoint)
@@ -247,12 +247,12 @@ Attribute                AB    BC    MB    NB    NL    NS    NT    NU    ON    P
 =====================  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  ====  =====
 Acquisition Technique   100   100   100     0     0   100     0     0   100   100     0   100     0    54
 Coverage                100   100   100     0     0   100     0     0     0   100     0   100     0    46
-Creation Date           100   100   100     0     0   100     0     0   100   100     0   100     0    54
+Creation Date           100   100   100     0     0   100     0     0     0   100     0   100     0    46
 Dataset Name            100   100   100     0     0   100     0     0   100   100     0   100     0    54
 Planimetric Accuracy    100   100   100     0     0   100     0     0   100   100     0   100     0    54
 Provider                100   100   100     0     0   100     0     0     0   100     0   100     0    46
 Revision Date           100   100   100     0     0   100     0     0   100   100     0   100     0    54
-Standard Version        100   100   100     0     0   100     0     0     0   100     0   100     0    46
+Standard Version        100   100   100     0     0   100     0     0   100   100     0   100     0    54
 NID                     100   100   100     0     0   100     0     0   100   100     0   100     0    54
 Road Element NID        100   100   100     0     0   100     0     0   100   100     0   100     0    54
 Toll Point Type         100   100   100     0     0   100     0     0   100   100     0   100     0    54

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Manitoba                   MB    6.0      2013-04       2012-04        89,003
 New Brunswick              NB    11.0     2021-06       2021-06        35,743              
 Newfoundland and Labrador  NL    7.0      2013-04       2012-09        23,026              
 Northwest Territories      NT    12.0     2021-04       2020-07        7,752               
-Nova Scotia                NS    14.0     2021-10       2021-09        51,895
+Nova Scotia                NS    14.1     2021-12       2021-09        51,895
 Nunavut                    NU    9.0      2021-04       2020-10        927                 
 Ontario                    ON    14.0     2021-12       2021-12        262,378             
 Prince Edward Island       PE    20.1     2021-08       2021-08        6,988               

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -20,7 +20,7 @@ Newfoundland and Labrador  NL    7.0      2013-04       2012-09        23,026
 Northwest Territories      NT    12.0     2021-04       2020-07        7,752               
 Nova Scotia                NS    14.0     2021-10       2021-09        51,895
 Nunavut                    NU    9.0      2021-04       2020-10        927                 
-Ontario                    ON    13.0     2020-12       2020-08        261,714             
+Ontario                    ON    14.0     2021-12       2021-12        262,378             
 Prince Edward Island       PE    20.1     2021-08       2021-08        6,988               
 Quebec                     QC    9.0      2016-08       2016-02        162,768             
 Saskatchewan               SK    11.0     2020-07       2020-05        251,860             

--- a/src/stage_1/sources/ns/roadseg.yaml
+++ b/src/stage_1/sources/ns/roadseg.yaml
@@ -13,7 +13,7 @@ license:
 language: en
 data:
   filename: 2021/NRN_Output.gdb
-  layer: NRN_ROADSEG
+  layer: NRN_ROADSEG_NEW
   driver: OpenFileGDB
   crs: "EPSG:2961"
   spatial: True

--- a/src/stage_4/validation_functions.py
+++ b/src/stage_4/validation_functions.py
@@ -167,53 +167,48 @@ class Validator:
                 "datasets": self.dframes.keys(),
                 "iterate": True
             },
-            self.conflicting_pavement_status: {
-                "code": 16,
-                "datasets": ["roadseg"],
-                "iterate": True
-            },
             self.point_proximity: {
-                "code": 17,
+                "code": 16,
                 "datasets": self.df_points,
                 "iterate": True
             },
             self.structure_attributes: {
-                "code": 18,
+                "code": 17,
                 "datasets": ["roadseg", "junction"],
                 "iterate": False
             },
             self.roadclass_rtnumber_relationship: {
-                "code": 19,
+                "code": 18,
                 "datasets": ["ferryseg", "roadseg"],
                 "iterate": True
             },
             self.self_intersecting_elements: {
-                "code": 20,
+                "code": 19,
                 "datasets": ["roadseg"],
                 "iterate": True
             },
             self.self_intersecting_structures: {
-                "code": 21,
+                "code": 20,
                 "datasets": ["roadseg"],
                 "iterate": True
             },
             self.route_contiguity: {
-                "code": 22,
+                "code": 21,
                 "datasets": ["roadseg"],
                 "iterate": False
             },
             self.speed: {
-                "code": 23,
+                "code": 22,
                 "datasets": ["roadseg"],
                 "iterate": True
             },
             self.encoding: {
-                "code": 24,
+                "code": 23,
                 "datasets": self.dframes.keys(),
                 "iterate": True
             },
             self.out_of_scope: {
-                "code": 25,
+                "code": 24,
                 "datasets": {*self.df_lines, *self.df_points} - {"junction"},
                 "iterate": True
             }
@@ -248,39 +243,6 @@ class Validator:
             for nid, exitnbrs in flag_nids.iteritems():
                 exitnbrs = ", ".join(map(lambda val: f"'{val}'", exitnbrs))
                 errors[1].append(f"nid '{nid}' has multiple exitnbrs: {exitnbrs}.")
-
-        return errors
-
-    def conflicting_pavement_status(self, name: str) -> Dict[int, list]:
-        """
-        Applies a set of validations to pavstatus, pavsurf, and unpavsurf fields.
-
-        :param str name: NRN dataset name.
-        :return Dict[int, list]: dictionary of validation codes and associated lists of error messages.
-        """
-
-        errors = defaultdict(list)
-        df = self.dframes[name]
-
-        # Subset dataframe to non-default values, keep only required fields.
-        default = self.defaults_all[name]["pavstatus"]
-        df_filtered = df.loc[df["pavstatus"] != default, ["pavstatus", "pavsurf", "unpavsurf"]]
-
-        # Apply validations and compile uuids of flagged records.
-        if len(df_filtered):
-
-            # Validation: when pavstatus == "Paved", ensure pavsurf != "None".
-            paved = df_filtered.loc[df_filtered["pavstatus"] == "Paved"]
-            errors[1] = paved.loc[paved["pavsurf"] == "None"].index.values
-
-            # Validation: when pavstatus == "Unpaved", ensure unpavsurf != "None".
-            unpaved = df_filtered.loc[df_filtered["pavstatus"] == "Unpaved"]
-            errors[2] = unpaved.loc[unpaved["unpavsurf"] == "None"].index.values
-
-        # Compile error properties.
-        for code, vals in errors.items():
-            if len(vals):
-                errors[code] = list(map(lambda val: f"uuid: '{val}'", vals))
 
         return errors
 

--- a/src/stage_5/distribution_docs/completion_rates.yaml
+++ b/src/stage_5/distribution_docs/completion_rates.yaml
@@ -61,7 +61,7 @@ addrange:
     yt: 100
   l_altnanid:
     ab: 0
-    avg: 8
+    avg: 0
     bc: 0
     mb: 0
     nb: 0
@@ -69,7 +69,7 @@ addrange:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 0
     qc: 0
     sk: 0
@@ -91,7 +91,7 @@ addrange:
     yt: 28
   l_hnumf:
     ab: 0
-    avg: 37
+    avg: 36
     bc: 0
     mb: 0
     nb: 100
@@ -99,14 +99,14 @@ addrange:
     ns: 100
     nt: 0
     nu: 100
-    'on': 99
+    'on': 84
     pe: 54
     qc: 0
     sk: 0
     yt: 28
   l_hnuml:
     ab: 0
-    avg: 37
+    avg: 36
     bc: 0
     mb: 0
     nb: 100
@@ -114,7 +114,7 @@ addrange:
     ns: 100
     nt: 0
     nu: 100
-    'on': 100
+    'on': 84
     pe: 54
     qc: 0
     sk: 0
@@ -129,7 +129,7 @@ addrange:
     ns: 100
     nt: 0
     nu: 100
-    'on': 98
+    'on': 100
     pe: 54
     qc: 0
     sk: 0
@@ -256,7 +256,7 @@ addrange:
     yt: 100
   provider:
     ab: 0
-    avg: 38
+    avg: 45
     bc: 0
     mb: 0
     nb: 100
@@ -264,14 +264,14 @@ addrange:
     ns: 100
     nt: 0
     nu: 100
-    'on': 0
+    'on': 84
     pe: 100
     qc: 0
     sk: 99
     yt: 1
   r_altnanid:
     ab: 0
-    avg: 8
+    avg: 0
     bc: 0
     mb: 0
     nb: 0
@@ -279,7 +279,7 @@ addrange:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 0
     qc: 0
     sk: 0
@@ -301,7 +301,7 @@ addrange:
     yt: 27
   r_hnumf:
     ab: 0
-    avg: 37
+    avg: 36
     bc: 0
     mb: 0
     nb: 100
@@ -309,14 +309,14 @@ addrange:
     ns: 100
     nt: 0
     nu: 100
-    'on': 100
+    'on': 84
     pe: 55
     qc: 0
     sk: 0
     yt: 27
   r_hnuml:
     ab: 0
-    avg: 37
+    avg: 36
     bc: 0
     mb: 0
     nb: 100
@@ -324,7 +324,7 @@ addrange:
     ns: 100
     nt: 0
     nu: 100
-    'on': 100
+    'on': 84
     pe: 55
     qc: 0
     sk: 0
@@ -339,7 +339,7 @@ addrange:
     ns: 100
     nt: 0
     nu: 100
-    'on': 98
+    'on': 100
     pe: 55
     qc: 0
     sk: 0
@@ -451,7 +451,7 @@ addrange:
     yt: 98
   specvers:
     ab: 0
-    avg: 54
+    avg: 62
     bc: 0
     mb: 0
     nb: 100
@@ -459,7 +459,7 @@ addrange:
     ns: 100
     nt: 100
     nu: 100
-    'on': 0
+    'on': 100
     pe: 100
     qc: 0
     sk: 100
@@ -603,7 +603,7 @@ blkpassage:
     yt: 100
   credate:
     ab: 100
-    avg: 77
+    avg: 69
     bc: 100
     mb: 100
     nb: 0
@@ -611,7 +611,7 @@ blkpassage:
     ns: 100
     nt: 100
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 0
     sk: 100
@@ -671,7 +671,7 @@ blkpassage:
     ns: 100
     nt: 100
     nu: 0
-    'on': 0
+    'on': 1
     pe: 100
     qc: 0
     sk: 99
@@ -708,7 +708,7 @@ blkpassage:
     yt: 100
   specvers:
     ab: 100
-    avg: 69
+    avg: 77
     bc: 100
     mb: 100
     nb: 0
@@ -716,7 +716,7 @@ blkpassage:
     ns: 100
     nt: 100
     nu: 0
-    'on': 0
+    'on': 100
     pe: 100
     qc: 0
     sk: 100
@@ -844,7 +844,7 @@ ferryseg:
     yt: 100
   provider:
     ab: 100
-    avg: 85
+    avg: 90
     bc: 100
     mb: 100
     nb: 100
@@ -852,7 +852,7 @@ ferryseg:
     ns: 100
     nt: 100
     nu: 0
-    'on': 0
+    'on': 70
     pe: 100
     qc: 100
     sk: 100
@@ -874,7 +874,7 @@ ferryseg:
     yt: 100
   roadclass:
     ab: 100
-    avg: 70
+    avg: 78
     bc: 100
     mb: 100
     nb: 0
@@ -882,14 +882,14 @@ ferryseg:
     ns: 8
     nt: 100
     nu: 0
-    'on': 0
+    'on': 100
     pe: 100
     qc: 100
     sk: 100
     yt: 100
   rtename1en:
     ab: 100
-    avg: 85
+    avg: 84
     bc: 100
     mb: 100
     nb: 100
@@ -897,14 +897,14 @@ ferryseg:
     ns: 0
     nt: 100
     nu: 0
-    'on': 100
+    'on': 96
     pe: 100
     qc: 100
     sk: 100
     yt: 100
   rtename1fr:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -912,14 +912,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 3
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtename2en:
     ab: 100
-    avg: 77
+    avg: 70
     bc: 100
     mb: 100
     nb: 100
@@ -927,14 +927,14 @@ ferryseg:
     ns: 0
     nt: 100
     nu: 0
-    'on': 100
+    'on': 6
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtename2fr:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -942,14 +942,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtename3en:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -957,14 +957,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtename3fr:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -972,14 +972,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtename4en:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -987,14 +987,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtename4fr:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -1002,14 +1002,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtnumber1:
     ab: 100
-    avg: 77
+    avg: 70
     bc: 100
     mb: 100
     nb: 100
@@ -1017,14 +1017,14 @@ ferryseg:
     ns: 0
     nt: 100
     nu: 0
-    'on': 100
+    'on': 6
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtnumber2:
     ab: 100
-    avg: 77
+    avg: 69
     bc: 100
     mb: 100
     nb: 100
@@ -1032,14 +1032,14 @@ ferryseg:
     ns: 0
     nt: 100
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtnumber3:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -1047,14 +1047,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtnumber4:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -1062,14 +1062,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   rtnumber5:
     ab: 100
-    avg: 69
+    avg: 62
     bc: 100
     mb: 100
     nb: 100
@@ -1077,14 +1077,14 @@ ferryseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 100
     sk: 0
     yt: 100
   specvers:
     ab: 100
-    avg: 85
+    avg: 92
     bc: 100
     mb: 100
     nb: 100
@@ -1092,7 +1092,7 @@ ferryseg:
     ns: 100
     nt: 100
     nu: 0
-    'on': 0
+    'on': 100
     pe: 100
     qc: 100
     sk: 100
@@ -1356,7 +1356,7 @@ roadseg:
     yt: 100
   exitnbr:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1364,7 +1364,7 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
@@ -1386,7 +1386,7 @@ roadseg:
     yt: 28
   l_hnumf:
     ab: 90
-    avg: 78
+    avg: 77
     bc: 100
     mb: 65
     nb: 100
@@ -1394,14 +1394,14 @@ roadseg:
     ns: 73
     nt: 6
     nu: 100
-    'on': 100
+    'on': 84
     pe: 54
     qc: 98
     sk: 100
     yt: 28
   l_hnuml:
     ab: 90
-    avg: 78
+    avg: 77
     bc: 100
     mb: 65
     nb: 100
@@ -1409,14 +1409,14 @@ roadseg:
     ns: 73
     nt: 6
     nu: 100
-    'on': 100
+    'on': 84
     pe: 54
     qc: 98
     sk: 100
     yt: 28
   l_placenam:
     ab: 100
-    avg: 95
+    avg: 89
     bc: 100
     mb: 100
     nb: 94
@@ -1424,7 +1424,7 @@ roadseg:
     ns: 73
     nt: 87
     nu: 100
-    'on': 85
+    'on': 4
     pe: 99
     qc: 96
     sk: 99
@@ -1506,7 +1506,7 @@ roadseg:
     yt: 100
   pavsurf:
     ab: 58
-    avg: 61
+    avg: 62
     bc: 16
     mb: 46
     nb: 99
@@ -1514,14 +1514,14 @@ roadseg:
     ns: 49
     nt: 100
     nu: 93
-    'on': 23
+    'on': 24
     pe: 100
     qc: 15
     sk: 69
     yt: 100
   provider:
     ab: 100
-    avg: 85
+    avg: 91
     bc: 100
     mb: 100
     nb: 100
@@ -1529,7 +1529,7 @@ roadseg:
     ns: 100
     nt: 99
     nu: 100
-    'on': 0
+    'on': 84
     pe: 100
     qc: 100
     sk: 99
@@ -1551,7 +1551,7 @@ roadseg:
     yt: 27
   r_hnumf:
     ab: 90
-    avg: 78
+    avg: 77
     bc: 100
     mb: 65
     nb: 100
@@ -1559,14 +1559,14 @@ roadseg:
     ns: 73
     nt: 6
     nu: 100
-    'on': 100
+    'on': 84
     pe: 55
     qc: 98
     sk: 100
     yt: 27
   r_hnuml:
     ab: 90
-    avg: 78
+    avg: 77
     bc: 100
     mb: 65
     nb: 100
@@ -1574,14 +1574,14 @@ roadseg:
     ns: 73
     nt: 6
     nu: 100
-    'on': 100
+    'on': 84
     pe: 55
     qc: 98
     sk: 100
     yt: 27
   r_placenam:
     ab: 100
-    avg: 95
+    avg: 89
     bc: 100
     mb: 100
     nb: 94
@@ -1589,7 +1589,7 @@ roadseg:
     ns: 73
     nt: 87
     nu: 100
-    'on': 85
+    'on': 4
     pe: 99
     qc: 96
     sk: 99
@@ -1634,7 +1634,7 @@ roadseg:
     ns: 97
     nt: 99
     nu: 83
-    'on': 100
+    'on': 98
     pe: 100
     qc: 100
     sk: 99
@@ -1671,7 +1671,7 @@ roadseg:
     yt: 100
   rtename1en:
     ab: 100
-    avg: 57
+    avg: 50
     bc: 100
     mb: 100
     nb: 100
@@ -1679,14 +1679,14 @@ roadseg:
     ns: 1
     nt: 15
     nu: 0
-    'on': 100
+    'on': 2
     pe: 3
     qc: 100
     sk: 1
     yt: 27
   rtename1fr:
     ab: 100
-    avg: 56
+    avg: 49
     bc: 100
     mb: 100
     nb: 100
@@ -1694,14 +1694,14 @@ roadseg:
     ns: 1
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 3
     qc: 100
     sk: 1
     yt: 27
   rtename2en:
     ab: 100
-    avg: 55
+    avg: 47
     bc: 100
     mb: 100
     nb: 100
@@ -1709,14 +1709,14 @@ roadseg:
     ns: 0
     nt: 12
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 1
   rtename2fr:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1724,14 +1724,14 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 1
   rtename3en:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1739,14 +1739,14 @@ roadseg:
     ns: 0
     nt: 1
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 0
   rtename3fr:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1754,14 +1754,14 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 0
   rtename4en:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1769,14 +1769,14 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 0
   rtename4fr:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1784,14 +1784,14 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 0
   rtnumber1:
     ab: 100
-    avg: 67
+    avg: 60
     bc: 100
     mb: 100
     nb: 99
@@ -1799,14 +1799,14 @@ roadseg:
     ns: 12
     nt: 11
     nu: 0
-    'on': 100
+    'on': 11
     pe: 36
     qc: 100
     sk: 9
     yt: 100
   rtnumber2:
     ab: 100
-    avg: 63
+    avg: 55
     bc: 100
     mb: 100
     nb: 100
@@ -1814,14 +1814,14 @@ roadseg:
     ns: 0
     nt: 11
     nu: 0
-    'on': 100
+    'on': 1
     pe: 1
     qc: 100
     sk: 1
     yt: 100
   rtnumber3:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1829,14 +1829,14 @@ roadseg:
     ns: 0
     nt: 1
     nu: 0
-    'on': 100
+    'on': 1
     pe: 1
     qc: 100
     sk: 1
     yt: 0
   rtnumber4:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1844,14 +1844,14 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 0
   rtnumber5:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 100
@@ -1859,14 +1859,14 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 0
     qc: 100
     sk: 1
     yt: 0
   specvers:
     ab: 100
-    avg: 92
+    avg: 100
     bc: 100
     mb: 100
     nb: 100
@@ -1874,7 +1874,7 @@ roadseg:
     ns: 100
     nt: 100
     nu: 100
-    'on': 0
+    'on': 100
     pe: 100
     qc: 100
     sk: 100
@@ -1926,7 +1926,7 @@ roadseg:
     yt: 1
   strunameen:
     ab: 98
-    avg: 54
+    avg: 46
     bc: 98
     mb: 97
     nb: 99
@@ -1934,14 +1934,14 @@ roadseg:
     ns: 0
     nt: 1
     nu: 0
-    'on': 100
+    'on': 1
     pe: 1
     qc: 100
     sk: 1
     yt: 1
   strunamefr:
     ab: 98
-    avg: 53
+    avg: 46
     bc: 98
     mb: 97
     nb: 96
@@ -1949,14 +1949,14 @@ roadseg:
     ns: 0
     nt: 0
     nu: 0
-    'on': 100
+    'on': 1
     pe: 1
     qc: 100
     sk: 1
     yt: 0
   trafficdir:
     ab: 61
-    avg: 57
+    avg: 49
     bc: 100
     mb: 0
     nb: 99
@@ -1964,7 +1964,7 @@ roadseg:
     ns: 98
     nt: 0
     nu: 88
-    'on': 100
+    'on': 0
     pe: 100
     qc: 0
     sk: 0
@@ -1979,7 +1979,7 @@ roadseg:
     ns: 50
     nt: 72
     nu: 93
-    'on': 76
+    'on': 75
     pe: 99
     qc: 83
     sk: 99
@@ -2115,7 +2115,7 @@ strplaname:
     ns: 100
     nt: 92
     nu: 100
-    'on': 99
+    'on': 97
     pe: 96
     qc: 0
     sk: 73
@@ -2137,7 +2137,7 @@ strplaname:
     yt: 100
   placename:
     ab: 0
-    avg: 60
+    avg: 53
     bc: 0
     mb: 0
     nb: 98
@@ -2145,7 +2145,7 @@ strplaname:
     ns: 100
     nt: 84
     nu: 100
-    'on': 100
+    'on': 5
     pe: 99
     qc: 0
     sk: 99
@@ -2167,7 +2167,7 @@ strplaname:
     yt: 73
   provider:
     ab: 0
-    avg: 46
+    avg: 53
     bc: 0
     mb: 0
     nb: 100
@@ -2175,7 +2175,7 @@ strplaname:
     ns: 100
     nt: 99
     nu: 100
-    'on': 0
+    'on': 93
     pe: 100
     qc: 0
     sk: 99
@@ -2212,7 +2212,7 @@ strplaname:
     yt: 95
   specvers:
     ab: 0
-    avg: 54
+    avg: 62
     bc: 0
     mb: 0
     nb: 100
@@ -2220,7 +2220,7 @@ strplaname:
     ns: 100
     nt: 100
     nu: 100
-    'on': 0
+    'on': 100
     pe: 100
     qc: 0
     sk: 100
@@ -2250,7 +2250,7 @@ strplaname:
     ns: 100
     nt: 1
     nu: 100
-    'on': 99
+    'on': 100
     pe: 4
     qc: 0
     sk: 17
@@ -2265,7 +2265,7 @@ strplaname:
     ns: 99
     nt: 81
     nu: 100
-    'on': 99
+    'on': 100
     pe: 91
     qc: 0
     sk: 55
@@ -2303,7 +2303,7 @@ tollpoint:
     yt: 0
   credate:
     ab: 100
-    avg: 54
+    avg: 46
     bc: 100
     mb: 100
     nb: 0
@@ -2311,7 +2311,7 @@ tollpoint:
     ns: 100
     nt: 0
     nu: 0
-    'on': 100
+    'on': 0
     pe: 100
     qc: 0
     sk: 100
@@ -2408,7 +2408,7 @@ tollpoint:
     yt: 0
   specvers:
     ab: 100
-    avg: 46
+    avg: 54
     bc: 100
     mb: 100
     nb: 0
@@ -2416,7 +2416,7 @@ tollpoint:
     ns: 100
     nt: 0
     nu: 0
-    'on': 0
+    'on': 100
     pe: 100
     qc: 0
     sk: 100

--- a/src/stage_5/distribution_docs/release_notes.yaml
+++ b/src/stage_5/distribution_docs/release_notes.yaml
@@ -39,10 +39,10 @@ nu:
   release_date: 2021-04
   validity_date: 2020-10
 'on':
-  edition: 13.0
-  number_of_kilometers: 261,714
-  release_date: 2020-12
-  validity_date: 2020-08
+  edition: 14.0
+  number_of_kilometers: 262,378
+  release_date: 2021-12
+  validity_date: 2021-12
 pe:
   edition: 20.1
   number_of_kilometers: 6,988

--- a/src/stage_5/stage.py
+++ b/src/stage_5/stage.py
@@ -11,6 +11,7 @@ from collections import Counter
 from datetime import datetime
 from operator import attrgetter, itemgetter
 from pathlib import Path
+from shapely.geometry import LineString
 from tqdm import tqdm
 from tqdm.auto import trange
 from typing import Union
@@ -250,6 +251,11 @@ class Stage:
 
                     # Iterate export datasets.
                     for table, df in dframes.items():
+
+                        # Reverse lat/lon ordering.
+                        df = df.copy(deep=True)
+                        df["geometry"] = df["geometry"].map(
+                            lambda g: LineString(pt[::-1] for pt in attrgetter("coords")(g)))
 
                         # Map dataframe queries (more efficient than iteratively querying).
                         self.kml_groups[lang]["df"] = self.kml_groups[lang]["query"].map(


### PR DESCRIPTION
Includes the following bug fixes:
- KML coordinate ordering patch (#142 )

Includes source updates for ON and NS (reissue) releases:
- ON (#76 )
- NS (#143 )

Additionally includes reconfiguration of readthedocs files.